### PR TITLE
Improve universal search frontend and embedding pipeline

### DIFF
--- a/seekedh-frontend/src/api.js
+++ b/seekedh-frontend/src/api.js
@@ -1,17 +1,26 @@
-const API_URL = import.meta.env.VITE_API_URL || "http://localhost:5000/api/rag/universal-search";
+const API_URL =
+  import.meta.env.VITE_API_URL ||
+  "http://localhost:5000/api/rag/universal-search";
 
+/**
+ * Query the universal-search endpoint.
+ *
+ * The backend returns objects under the `cards` key and supports an
+ * `include_images` flag to embed image information.  The testing suite
+ * uses this flag so we mirror that behaviour here.
+ */
 export async function universalCardSearch(query) {
   try {
     const res = await fetch(API_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query }),
+      body: JSON.stringify({ query, include_images: true }),
     });
     if (!res.ok) throw new Error("API error");
     const data = await res.json();
-    // Adapt as needed for your backend's response shape
-    return data.results || [];
+    return data.cards || [];
   } catch (e) {
+    console.error("search error", e);
     return [];
   }
 }

--- a/seekedh-frontend/src/components/CardResultsGrid.jsx
+++ b/seekedh-frontend/src/components/CardResultsGrid.jsx
@@ -31,6 +31,11 @@ export default function CardResultsGrid({ results, loading }) {
             />
           </div>
           <div className="font-bold text-xl">{card.name}</div>
+          {card.combined_synergy_score !== undefined && (
+            <div className="text-xs text-blue-400">
+              Synergy: {(card.combined_synergy_score * 100).toFixed(1)}%
+            </div>
+          )}
           <div className="text-sm text-gray-400">{card.type_line}</div>
           <div className="mt-1 text-gray-300">{card.oracle_text}</div>
           <div className="mt-2 text-xs text-gray-500">Set: {card.set_name || "—"}</div>

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -8,6 +8,7 @@ import pandas as pd
 import numpy as np
 import hashlib
 import time
+import torch
 from pathlib import Path
 from urllib.parse import urlparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -453,9 +454,11 @@ class MTGDataPipeline:
         try:
             # Load processed cards
             df = pd.read_csv(self.processed_data_path)
-            
-            # Initialize the embedding model
-            model = SentenceTransformer(model_name)
+
+            # Initialize the embedding model with an explicit device
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            logger.info(f"Loading embedding model on {device}")
+            model = SentenceTransformer(model_name, device=device)
             
             # Prepare text for embedding with enhanced processing
             texts = []


### PR DESCRIPTION
## Summary
- update universal-search API client to request images
- show synergy score on frontend card list
- load embedding model on the correct device in data pipeline

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `python -m py_compile src/data_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6841c2a076fc8328922f46d137c7281f