### PR TITLE
Add verbose logs for DB import

### DIFF
--- a/static/js/database.js
+++ b/static/js/database.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('dbImportBtn').addEventListener('click', function() {
         toggleLoading('db', true);
         
-        makeApiRequest(`${getApiUrl()}/api/database/import`, 'POST', { include_price_embeddings: true })
+        makeApiRequest(`${getApiUrl()}/api/database/import`, 'POST', { include_price_embeddings: true, verbose: true })
             .then(data => {
                 displayResult('db', data);
             })


### PR DESCRIPTION
## Summary
- allow capturing logs in /api/database/import endpoint
- send `verbose` option from the frontend

## Testing
- `python -m py_compile src/api_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a600bcec832894d019796b5d79d6