### PR TITLE
Add enhanced search UI with color filters

### DIFF
--- a/seekedh-frontend/README.md
+++ b/seekedh-frontend/README.md
@@ -1,6 +1,17 @@
-# React + Vite
+# seekedh Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This React app provides a simple interface for the **enhanced card search** API.
+It allows you to query the backend and filter results by card colors. Images are
+displayed using `object-contain` so artwork is never cropped.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+The API base URL can be customised with the `VITE_API_URL` environment variable.
 
 Currently, two official plugins are available:
 

--- a/seekedh-frontend/src/api.js
+++ b/seekedh-frontend/src/api.js
@@ -1,6 +1,7 @@
-const API_URL =
-  import.meta.env.VITE_API_URL ||
-  "http://localhost:5000/api/rag/universal-search";
+const BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:5000";
+
+const UNIVERSAL_URL = `${BASE_URL}/api/rag/universal-search`;
+const ENHANCED_URL = `${BASE_URL}/api/rag/enhanced-search`;
 
 /**
  * Query the universal-search endpoint.
@@ -11,7 +12,7 @@ const API_URL =
  */
 export async function universalCardSearch(query) {
   try {
-    const res = await fetch(API_URL, {
+    const res = await fetch(UNIVERSAL_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ query, include_images: true }),
@@ -21,6 +22,25 @@ export async function universalCardSearch(query) {
     return data.cards || [];
   } catch (e) {
     console.error("search error", e);
+    return [];
+  }
+}
+
+/**
+ * Query the enhanced-search endpoint with optional filters.
+ */
+export async function enhancedCardSearch(query, filters = {}) {
+  try {
+    const res = await fetch(ENHANCED_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query, filters, include_images: true }),
+    });
+    if (!res.ok) throw new Error("API error");
+    const data = await res.json();
+    return data.cards || [];
+  } catch (e) {
+    console.error("enhanced search error", e);
     return [];
   }
 }

--- a/seekedh-frontend/src/components/CardResultsGrid.jsx
+++ b/seekedh-frontend/src/components/CardResultsGrid.jsx
@@ -26,7 +26,7 @@ export default function CardResultsGrid({ results, loading }) {
             <img
               src={card.image_url || "/default_card.png"}
               alt={card.name}
-              className="w-full h-64 object-contain rounded-lg"
+              className="w-full max-h-96 object-contain rounded-lg"
               loading="lazy"
             />
           </div>

--- a/seekedh-frontend/src/components/CardSearchBar.jsx
+++ b/seekedh-frontend/src/components/CardSearchBar.jsx
@@ -1,36 +1,68 @@
 import React, { useState } from "react";
-import { universalCardSearch } from "../api";
+import { enhancedCardSearch } from "../api";
 
 export default function CardSearchBar({ setResults, setLoading, loading }) {
   const [query, setQuery] = useState("");
+  const [colors, setColors] = useState([]);
+
+  const toggleColor = (color) => {
+    setColors((prev) =>
+      prev.includes(color)
+        ? prev.filter((c) => c !== color)
+        : [...prev, color]
+    );
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!query.trim()) return;
     setLoading(true);
-    const results = await universalCardSearch(query);
+    const filters = {};
+    if (colors.length) filters.colors = colors;
+    const results = await enhancedCardSearch(query, filters);
     setResults(results);
     setLoading(false);
   };
 
   return (
-    <form onSubmit={handleSubmit} className="w-full max-w-xl flex gap-2 mb-8">
-      <input
-        className="flex-1 p-4 rounded-xl bg-gray-800 border border-gray-700 text-white outline-none text-lg transition-all focus:ring-2 focus:ring-blue-500"
-        type="text"
-        placeholder="Search for any card, combo, keyword, or synergy..."
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        disabled={loading}
-        autoFocus
-      />
-      <button
-        type="submit"
-        className="px-6 py-2 rounded-xl bg-blue-600 hover:bg-blue-700 transition disabled:opacity-50 font-semibold text-lg"
-        disabled={loading}
-      >
-        {loading ? "Searching..." : "Search"}
-      </button>
+    <form onSubmit={handleSubmit} className="w-full max-w-xl flex flex-col gap-3 mb-8">
+      <div className="flex flex-wrap justify-center gap-3">
+        {[
+          { code: "W", label: "White" },
+          { code: "U", label: "Blue" },
+          { code: "B", label: "Black" },
+          { code: "R", label: "Red" },
+          { code: "G", label: "Green" },
+        ].map((c) => (
+          <label key={c.code} className="flex items-center gap-1 text-sm">
+            <input
+              type="checkbox"
+              checked={colors.includes(c.code)}
+              onChange={() => toggleColor(c.code)}
+              className="form-checkbox text-blue-500"
+            />
+            {c.label}
+          </label>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 p-4 rounded-xl bg-gray-800 border border-gray-700 text-white outline-none text-lg transition-all focus:ring-2 focus:ring-blue-500"
+          type="text"
+          placeholder="Search for any card, combo, keyword, or synergy..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          disabled={loading}
+          autoFocus
+        />
+        <button
+          type="submit"
+          className="px-6 py-2 rounded-xl bg-blue-600 hover:bg-blue-700 transition disabled:opacity-50 font-semibold text-lg"
+          disabled={loading}
+        >
+          {loading ? "Searching..." : "Search"}
+        </button>
+      </div>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- support enhanced card search API from the frontend
- allow selecting card colors when searching
- ensure card images keep their aspect ratio
- document how to run the frontend

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845be5d974c832899fa9c5cf4621d69