### PR TITLE
Improve universal search

### DIFF
--- a/src/enhanced_universal_search.py
+++ b/src/enhanced_universal_search.py
@@ -168,7 +168,7 @@ class EnhancedUniversalSearchHandler:
             'deck_context': None
         }
 
-        # Extract colors
+        # Extract colors from full words
         for color_word, color_codes in self.category_patterns['colors'].items():
             if color_word in query_lower:
                 if isinstance(color_codes, list):
@@ -177,6 +177,13 @@ class EnhancedUniversalSearchHandler:
                     constraints['mono'] = True
                 elif color_codes == 'multi':
                     constraints['multicolor'] = True
+
+        # NEW: Extract color abbreviations like "UB" or "WUG"
+        abbr_matches = re.findall(r'\b[WUBRG]{1,5}\b', query_text.upper())
+        for abbr in abbr_matches:
+            for letter in abbr:
+                if letter not in constraints['colors']:
+                    constraints['colors'].append(letter)
 
         # Extract card types
         for type_word, type_name in self.category_patterns['types'].items():

--- a/static/index.html
+++ b/static/index.html
@@ -92,7 +92,7 @@
                             <div class="image-grid-item hoverable-card" onclick="showImageModal('${card.name}', ${JSON.stringify(card).replace(/"/g, '&quot;')})">
                                 <div class="position-relative">
                                     ${imageUrl ? 
-                                        `<img src="${imageUrl}" class="card-image hover-zoom" alt="${card.name}" loading="lazy">
+                                        `<img src="${imageUrl}" class="card-image-small hover-enlarge" alt="${card.name}" loading="lazy">
                                          <span class="card-image-status status-${imageStatus}">${imageStatus}</span>` :
                                         `<div class="card-image-placeholder">No Image</div>`
                                     }
@@ -189,6 +189,16 @@
             z-index: 10;
             position: relative;
         }
+
+        /* Larger zoom for card previews */
+        .hover-enlarge {
+            transition: transform 0.2s ease;
+        }
+        .hover-enlarge:hover {
+            transform: scale(2);
+            z-index: 20;
+            position: relative;
+        }
         
         .hoverable-card {
             cursor: pointer;
@@ -245,7 +255,7 @@
         }
         
         .image-grid .image-grid-item {
-            min-height: 300px;
+            min-height: 220px;
         }
         
         .card-image {
@@ -793,7 +803,7 @@
                             <div class="image-grid-item hoverable-card" onclick="showImageModal('${card.name}', ${JSON.stringify(card).replace(/"/g, '&quot;')})">
                                 <div class="position-relative">
                                     ${imageUrl ? 
-                                        `<img src="${imageUrl}" class="card-image hover-zoom" alt="${card.name}" loading="lazy">` :
+                                        `<img src="${imageUrl}" class="card-image-small hover-enlarge" alt="${card.name}" loading="lazy">` :
                                         `<div class="card-image-placeholder">No Image</div>`
                                     }
                                     <span class="badge bg-success position-absolute top-0 end-0 m-2">${synergyScore}%</span>
@@ -845,7 +855,7 @@
                             <div class="image-grid-item hoverable-card" onclick="showImageModal('${card.name}', ${JSON.stringify(card).replace(/"/g, '&quot;')})">
                                 <div class="position-relative">
                                     ${imageUrl ? 
-                                        `<img src="${imageUrl}" class="card-image hover-zoom" alt="${card.name}" loading="lazy">` :
+                                        `<img src="${imageUrl}" class="card-image-small hover-enlarge" alt="${card.name}" loading="lazy">` :
                                         `<div class="card-image-placeholder">No Image</div>`
                                     }
                                     <span class="badge bg-info position-absolute top-0 end-0 m-2">${similarity}%</span>
@@ -903,7 +913,7 @@
                             <div class="image-grid-item hoverable-card" onclick="showImageModal('${card.name}', ${JSON.stringify(card).replace(/"/g, '&quot;')})">
                                 <div class="position-relative">
                                     ${imageUrl ? 
-                                        `<img src="${imageUrl}" class="card-image hover-zoom" alt="${card.name}" loading="lazy">` :
+                                        `<img src="${imageUrl}" class="card-image-small hover-enlarge" alt="${card.name}" loading="lazy">` :
                                         `<div class="card-image-placeholder">No Image</div>`
                                     }
                                 </div>

--- a/tests/test_universal_search.py
+++ b/tests/test_universal_search.py
@@ -1,0 +1,37 @@
+import unittest
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.enhanced_universal_search import EnhancedUniversalSearchHandler
+
+class DummyDB:
+    is_connected = False
+    client = None
+
+class DummyRAG:
+    def __init__(self):
+        self.db = DummyDB()
+        self.embedding_model = None
+        self.embedding_available = False
+        self.text_index = None
+    def search_cards_by_keyword(self, keyword, top_k=3):
+        return []
+    def retrieve_cards_by_text(self, text, top_k=20):
+        return []
+
+class TestColorExtraction(unittest.TestCase):
+    def setUp(self):
+        self.handler = EnhancedUniversalSearchHandler(DummyRAG())
+
+    def test_color_abbreviations(self):
+        constraints = self.handler.extract_constraints("Looking for a UB artifact")
+        self.assertIn('U', constraints['colors'])
+        self.assertIn('B', constraints['colors'])
+
+    def test_multi_color_abbrev(self):
+        constraints = self.handler.extract_constraints("Need a WUG ramp deck")
+        self.assertEqual(set(constraints['colors']), {'W','U','G'})
+        self.assertIn('ramp', constraints['strategies'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- detect color abbreviations like `UB` or `WUG`
- use a global universal search handler in the API server
- route the `/api/rag/enhanced-search` endpoint through the universal search handler
- add unit tests for color abbreviation parsing
- shrink search result images and add hover enlargement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f70e7c7508328b71c7e65a0cc3735